### PR TITLE
remove lock files to ensure :1 is available on restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ build: nvidia ubuntu
 
 run_nvidia: nvidia
 	@echo "Running the project..."
-	-docker run --rm --gpus all -p 5801:5801 -it $(NVIDIA_DEST_TAG) /bin/bash
+	-docker run --rm --gpus all -p 5801 -it $(NVIDIA_DEST_TAG) /bin/bash
 
 run_ubuntu: ubuntu
 	@echo "Running the project..."
-	-docker run --rm -p 5801:5801 -it $(UBUNTU_DEST_TAG) /bin/bash
+	-docker run --rm -p 5801 -it $(UBUNTU_DEST_TAG) /bin/bash
 

--- a/start-turbovnc.sh
+++ b/start-turbovnc.sh
@@ -3,6 +3,7 @@ echo "starting turbovnc"
 sudo rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1
 screen -dmS turbovnc bash -c 'VGL_DISPLAY=egl VGL_FPS=30 /opt/TurboVNC/bin/vncserver :1 -depth 24 -noxstartup -securitytypes TLSNone,X509None,None 2>&1 | tee /tmp/vnc.log; read -p "Press any key to continue..."'
 # wait for VNC to be running
+echo "waiting for turbovnc to be up (display not available messages are expected during this time)"
 while ! xdpyinfo -display :1 > /dev/null; do
     sleep 1
 done

--- a/start-turbovnc.sh
+++ b/start-turbovnc.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 echo "starting turbovnc"
-screen -dmS turbovnc bash -c 'VGL_DISPLAY=egl VGL_FPS=30 /opt/TurboVNC/bin/vncserver -depth 24 -noxstartup -securitytypes TLSNone,X509None,None 2>&1 | tee /tmp/vnc.log; read -p "Press any key to continue..."'
+sudo rm -rf /tmp/.X1-lock /tmp/.X11-unix/X1
+screen -dmS turbovnc bash -c 'VGL_DISPLAY=egl VGL_FPS=30 /opt/TurboVNC/bin/vncserver :1 -depth 24 -noxstartup -securitytypes TLSNone,X509None,None 2>&1 | tee /tmp/vnc.log; read -p "Press any key to continue..."'
 # wait for VNC to be running
 while ! xdpyinfo -display :1 > /dev/null; do
     sleep 1


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

always start as Xvnc on `:1` and ensure no lock files prevent it.

