### PR TITLE
attempt multi-arch build

### DIFF
--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -37,6 +37,9 @@ jobs:
               push_tag: jammy-humble-cuda12.6-opengl
   
     steps:
+    # set up buildx
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Node Js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -163,7 +163,7 @@ jobs:
       with:
         context: .
         file: ./Dockerfile.opengl
-        platforms: linux/arm64
+        platforms: linux/arm64,linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/docker-build-opengl.yaml` file to enhance the Docker build process.

Docker build process improvement:

* Added support for building Docker images on both `linux/arm64` and `linux/amd64` platforms in the `docker-build-opengl.yaml` workflow file.