### PR TITLE
install zenoh

### DIFF
--- a/Dockerfile.opengl
+++ b/Dockerfile.opengl
@@ -152,6 +152,16 @@ RUN curl -o /etc/ros/rosdep/sources.list.d/20-default.list https://raw.githubuse
 
 ENV ROSDISTRO_INDEX_URL=https://raw.github.com/LCAS/rosdistro/master/index-v4.yaml
 
+# install Zenoh
+RUN mkdir -p /tmp/zenoh-build && \ 
+    cd /tmp/zenoh-build && \
+    (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) && \
+    git clone https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git && \
+    cd /tmp/zenoh-build/zenoh-plugin-ros2dds && \
+    /bin/bash -c "source '$HOME/.cargo/env'; cargo build --release -p zenoh-bridge-ros2dds" && \
+    install target/release/zenoh-bridge-ros2dds /usr/local/bin/
+
+
 ENV DEBIAN_FRONTEND=
 
 ###########################################

--- a/Dockerfile.opengl
+++ b/Dockerfile.opengl
@@ -156,7 +156,7 @@ ENV ROSDISTRO_INDEX_URL=https://raw.github.com/LCAS/rosdistro/master/index-v4.ya
 RUN mkdir -p /tmp/zenoh-build && \ 
     cd /tmp/zenoh-build && \
     (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) && \
-    git clone https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git && \
+    git clone --depth 1 -b 1.0.4 https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git && \
     cd /tmp/zenoh-build/zenoh-plugin-ros2dds && \
     /bin/bash -c "source '$HOME/.cargo/env'; cargo build --release -p zenoh-bridge-ros2dds" && \
     install target/release/zenoh-bridge-ros2dds /usr/local/bin/


### PR DESCRIPTION
This pull request includes a change to the `Dockerfile.opengl` to add the installation of Zenoh. The most important change is the addition of a series of commands to download, build, and install the Zenoh bridge for ROS2 DDS.

Installation of Zenoh:

* [`Dockerfile.opengl`](diffhunk://#diff-3cabaf886efb60d72b81656b846e6d4be9f9c767e17d0ff162a0b1cbd8f984e9R155-R164): Added commands to create a temporary build directory, download and install Rust, clone the Zenoh repository, build the Zenoh bridge for ROS2 DDS, and install the resulting binary.