### PR TITLE
add cache-from option for Docker builds in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -70,10 +70,10 @@ jobs:
           lcas.lincoln.ac.uk/lcas/ros
         # generate Docker tags based on the following events/attributes
         tags: |
+          type=raw,value=${{ matrix.push_tag }}-staging
           type=raw,enable=${{ github.event_name != 'pull_request' }},value=${{ matrix.push_tag }}
           type=raw,enable=${{ github.event_name != 'pull_request' }},value=${{ matrix.push_tag }}-amd64
-          type=ref,event=branch,prefix=${{ matrix.push_tag }}-
-          type=ref,event=pr,prefix=${{ matrix.push_tag }}-pr-
+          type=ref,enable=${{ github.event_name != 'pull_request' }},event=branch,prefix=${{ matrix.push_tag }}-
           type=semver,pattern={{version}},prefix=${{ matrix.push_tag }}-
           type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.push_tag }}-
           type=semver,pattern={{major}},prefix=${{ matrix.push_tag }}-
@@ -154,9 +154,9 @@ jobs:
           lcas.lincoln.ac.uk/lcas/ros
         # generate Docker tags based on the following events/attributes
         tags: |
+          type=raw,value=${{ matrix.push_tag }}-staging
           type=raw,enable=${{ github.event_name != 'pull_request' }},value=${{ matrix.push_tag }}
-          type=ref,event=branch,prefix=${{ matrix.push_tag }}-
-          type=ref,event=pr,prefix=${{ matrix.push_tag }}-pr-
+          type=ref,enable=${{ github.event_name != 'pull_request' }},event=branch,prefix=${{ matrix.push_tag }}-
           type=semver,pattern={{version}},prefix=${{ matrix.push_tag }}-
           type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.push_tag }}-
           type=semver,pattern={{major}},prefix=${{ matrix.push_tag }}-

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -86,7 +86,8 @@ jobs:
         file: ./Dockerfile.opengl
         platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
-        cache-from: type=registry,ref=lcas.lincoln.ac.uk/lcas/ros:${{ matrix.push_tag }}
+        cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
+        cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
@@ -165,7 +166,8 @@ jobs:
         context: .
         file: ./Dockerfile.opengl
         platforms: linux/arm64
-        cache-from: type=registry,ref=lcas.lincoln.ac.uk/lcas/ros:${{ matrix.push_tag }}
+        cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
+        cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -86,6 +86,7 @@ jobs:
         file: ./Dockerfile.opengl
         platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
+        cache-from: type=registry,ref=lcas.lincoln.ac.uk/lcas/ros:${{ matrix.push_tag }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
@@ -164,6 +165,7 @@ jobs:
         context: .
         file: ./Dockerfile.opengl
         platforms: linux/arm64
+        cache-from: type=registry,ref=lcas.lincoln.ac.uk/lcas/ros:${{ matrix.push_tag }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -87,7 +87,7 @@ jobs:
         context: .
         file: ./Dockerfile.opengl
         platforms: linux/amd64
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
         cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
         tags: ${{ steps.meta.outputs.tags }}
@@ -172,7 +172,7 @@ jobs:
         platforms: linux/arm64
         cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
         cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -79,6 +79,9 @@ jobs:
           type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.push_tag }}-
           type=semver,pattern={{major}},prefix=${{ matrix.push_tag }}-
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
     - name: Build Docker Image
       uses: docker/build-push-action@v6
       with:
@@ -160,6 +163,9 @@ jobs:
           type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.push_tag }}-
           type=semver,pattern={{major}},prefix=${{ matrix.push_tag }}-
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
     - name: Build Docker Image
       uses: docker/build-push-action@v6
       with:

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -45,7 +45,6 @@ jobs:
     - name: What
       run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
     - name: Docker Login LCAS
-      if: ${{ github.event_name != 'pull_request' }}
       # You may pin to the exact commit or the version.
       # uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       uses: docker/login-action@v3

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -26,9 +26,9 @@ jobs:
             - base_image: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
               ros_distro: humble
               push_tag: jammy-humble-cuda11.8-opengl
-            - base_image: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
-              ros_distro: humble
-              push_tag: jammy-humble-cuda12.1-opengl
+            # - base_image: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+            #   ros_distro: humble
+            #   push_tag: jammy-humble-cuda12.1-opengl
             - base_image: nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
               ros_distro: humble
               push_tag: jammy-humble-cuda12.2-opengl
@@ -110,9 +110,9 @@ jobs:
             - base_image: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
               ros_distro: humble
               push_tag: jammy-humble-cuda11.8-opengl-arm64
-            - base_image: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
-              ros_distro: humble
-              push_tag: jammy-humble-cuda12.1-opengl-arm64
+            # - base_image: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+            #   ros_distro: humble
+            #   push_tag: jammy-humble-cuda12.1-opengl-arm64
             - base_image: nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
               ros_distro: humble
               push_tag: jammy-humble-cuda12.2-opengl-arm64
@@ -129,7 +129,6 @@ jobs:
     - name: What
       run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
     - name: Docker Login LCAS
-      if: ${{ github.event_name != 'pull_request' }}
       # You may pin to the exact commit or the version.
       # uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       uses: docker/login-action@v3

--- a/Dockerfile.opengl
+++ b/Dockerfile.opengl
@@ -159,7 +159,7 @@ ENV ROSDISTRO_INDEX_URL=https://raw.github.com/LCAS/rosdistro/master/index-v4.ya
 RUN mkdir -p /tmp/zenoh-build && \ 
     cd /tmp/zenoh-build && \
     (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y) && \
-    git clone --depth 1 -b 1.0.4 https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git && \
+    git clone --depth 1 -b 1.1.0 https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git && \
     cd /tmp/zenoh-build/zenoh-plugin-ros2dds && \
     /bin/bash -c "source '$HOME/.cargo/env'; cargo build --release -p zenoh-bridge-ros2dds" && \
     install target/release/zenoh-bridge-ros2dds /usr/local/bin/

--- a/Dockerfile.opengl
+++ b/Dockerfile.opengl
@@ -192,8 +192,8 @@ ENV DEBIAN_FRONTEND=
 
 # Install noVNC
 
-ENV NOVNC_VERSION=1.4.0
-ENV WEBSOCKETIFY_VERSION=0.10.0
+ENV NOVNC_VERSION=1.5.0
+ENV WEBSOCKETIFY_VERSION=0.12.0
 
 RUN mkdir -p /usr/local/novnc && \
     curl -sSL https://github.com/novnc/noVNC/archive/v${NOVNC_VERSION}.zip -o /tmp/novnc-install.zip && \


### PR DESCRIPTION
This pull request includes updates to the Docker build workflow configuration in the `.github/workflows/docker-build-opengl.yaml` file. The changes focus on improving the caching mechanism for the Docker build process.

Enhancements to Docker build caching:

* [`.github/workflows/docker-build-opengl.yaml`](diffhunk://#diff-595efa52ba7cdc0240a7d881238485c57b8abec69f6e8bc010050fcde533fb19R89): Added `cache-from` parameter to the `linux/amd64` build job to utilize registry-based caching.
* [`.github/workflows/docker-build-opengl.yaml`](diffhunk://#diff-595efa52ba7cdc0240a7d881238485c57b8abec69f6e8bc010050fcde533fb19R168): Added `cache-from` parameter to the `linux/arm64` build job to utilize registry-based caching.