### PR TITLE
Update Dockerfile to include setuptools upgrade for known issue fix

### DIFF
--- a/nvidia.dockerfile
+++ b/nvidia.dockerfile
@@ -285,6 +285,8 @@ ENV PATH="${HOME}/.local/venv/bin:$PATH"
 COPY --chown=ros:ros requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
     rm /tmp/requirements.txt
+# needed as quick fix for https://github.com/pypa/setuptools/issues/4483
+RUN pip install -U setuptools[core]
 
 USER root
 COPY .gi? /tmp/gittemp/.git


### PR DESCRIPTION
Upgrade setuptools in the Dockerfile as a quick fix for the issue reported in https://github.com/pypa/setuptools/issues/4483. This change ensures that the environment is set up correctly to avoid the TypeError encountered during package installation.