### PR TITLE
better build cache

### DIFF
--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -93,8 +93,6 @@ jobs:
         file: ./nvidia.dockerfile
         platforms: linux/amd64
         push: true
-        cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
-        cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
@@ -180,8 +178,6 @@ jobs:
         context: .
         file: ./nvidia.dockerfile
         platforms: linux/arm64
-        cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
-        cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas/ros:${{ matrix.push_tag }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -93,6 +93,9 @@ jobs:
         file: ./nvidia.dockerfile
         platforms: linux/amd64
         push: true
+        load: true
+        cache-from: type=local,src=/tmp/cache
+        cache-to: type=local,src=/tmp/cache
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
@@ -179,6 +182,9 @@ jobs:
         file: ./nvidia.dockerfile
         platforms: linux/arm64
         push: true
+        load: true
+        cache-from: type=local,src=/tmp/cache
+        cache-to: type=local,src=/tmp/cache
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -94,8 +94,8 @@ jobs:
         platforms: linux/amd64
         push: true
         load: true
-        cache-from: type=local,src=/tmp/cache
-        cache-to: type=local,dest=/tmp/cache,mode=max
+        cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas_ros:${{ matrix.push_tag }}-staging
+        cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas_ros:${{ matrix.push_tag }}-staging,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -95,7 +95,7 @@ jobs:
         push: true
         load: true
         cache-from: type=local,src=/tmp/cache
-        cache-to: type=local,src=/tmp/cache
+        cache-to: type=local,dest=/tmp/cache
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
@@ -184,7 +184,7 @@ jobs:
         push: true
         load: true
         cache-from: type=local,src=/tmp/cache
-        cache-to: type=local,src=/tmp/cache
+        cache-to: type=local,dest=/tmp/cache
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -85,7 +85,12 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-      
+      with:
+        buildkitd-config-inline: |
+          [registry."cache"]
+            http = true
+            insecure = true
+
     - name: "image name from repo name"
       id: docker_image_name
       run: echo "docker_image=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' |sed 's/[^0-9,a-z,A-Z,=,_,\/]/-/g' >>${GITHUB_OUTPUT}

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -87,7 +87,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         buildkitd-config-inline: |
-          [registry."cache"]
+          [registry."cache:5000"]
             http = true
             insecure = true
 

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -95,7 +95,7 @@ jobs:
         push: true
         load: true
         cache-from: type=local,src=/tmp/cache
-        cache-to: type=local,dest=/tmp/cache
+        cache-to: type=local,dest=/tmp/cache,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
@@ -184,7 +184,7 @@ jobs:
         push: true
         load: true
         cache-from: type=local,src=/tmp/cache
-        cache-to: type=local,dest=/tmp/cache
+        cache-to: type=local,dest=/tmp/cache,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -70,10 +70,10 @@ jobs:
         labels: |
           org.opencontainers.image.description=L-CAS ROS2 Docker Image with virtual X11 embedded (flavour: ${{ matrix.push_tag }})
           org.opencontainers.image.authors=L-CAS Team
-        # list of Docker images to use as base name for tags
+        
         images: |
           lcas.lincoln.ac.uk/lcas/ros
-        # generate Docker tags based on the following events/attributes
+        
         tags: |
           type=raw,value=${{ matrix.push_tag }}-staging
           type=raw,enable=${{ github.event_name != 'pull_request' }},value=${{ matrix.push_tag }}

--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -86,6 +86,10 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       
+    - name: "image name from repo name"
+      id: docker_image_name
+      run: echo "docker_image=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' |sed 's/[^0-9,a-z,A-Z,=,_,\/]/-/g' >>${GITHUB_OUTPUT}
+
     - name: Build Docker Image
       uses: docker/build-push-action@v6
       with:
@@ -93,9 +97,8 @@ jobs:
         file: ./nvidia.dockerfile
         platforms: linux/amd64
         push: true
-        load: true
-        cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas_ros:${{ matrix.push_tag }}-staging
-        cache-to: type=registry,ref=lcas.lincoln.ac.uk/cache/lcas_ros:${{ matrix.push_tag }}-staging,mode=max
+        cache-from: type=registry,ref=cache:5000/${{ steps.docker_image_name.outputs.docker_image }}:${{ matrix.push_tag }}
+        cache-to: type=registry,ref=cache:5000/${{ steps.docker_image_name.outputs.docker_image }}:${{ matrix.push_tag }},mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
@@ -175,6 +178,10 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       
+    - name: "image name from repo name"
+      id: docker_image_name
+      run: echo "docker_image=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' |sed 's/[^0-9,a-z,A-Z,=,_,\/]/-/g' >>${GITHUB_OUTPUT}
+
     - name: Build Docker Image
       uses: docker/build-push-action@v6
       with:
@@ -182,9 +189,8 @@ jobs:
         file: ./nvidia.dockerfile
         platforms: linux/arm64
         push: true
-        load: true
-        cache-from: type=local,src=/tmp/cache
-        cache-to: type=local,dest=/tmp/cache,mode=max
+        cache-from: type=registry,ref=cache:5000/${{ steps.docker_image_name.outputs.docker_image }}:${{ matrix.push_tag }}
+        cache-to: type=registry,ref=cache:5000/${{ steps.docker_image_name.outputs.docker_image }}:${{ matrix.push_tag }},mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |

--- a/nvidia.dockerfile
+++ b/nvidia.dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 \
     lsb-release \
     sudo \
+    python3-setuptools \
     software-properties-common \
     wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-build-opengl.yaml` file, specifically related to the caching configuration for Docker builds. The most important changes involve the removal of `cache-from` and `cache-to` directives.

Changes in Docker build caching configuration:

* Removed `cache-from` and `cache-to` directives from the `linux/amd64` build configuration.
* Removed `cache-from` and `cache-to` directives from the `linux/arm64` build configuration.