### PR TITLE
Fix Dockerfile syntax and update virtual environment setup

### DIFF
--- a/nvidia.dockerfile
+++ b/nvidia.dockerfile
@@ -269,7 +269,7 @@ RUN curl -sSLfo /tmp/zrok-install.bash https://get.openziti.io/install.bash && \
     rm /tmp/zrok-install.bash
 
 
-RUN mkdir -p /opt/image
+RUN mkdir -p /opt/image && mkdir -p /opt/venv && chown ros:ros /opt/venv
 
 ###########################################
 FROM openglvnc AS user
@@ -281,9 +281,9 @@ RUN mkdir -p ${HOME}/.local/bin
 # install a Python venv overlay to allow pip and friends
 ENV PYTHONUNBUFFERED=1
 ENV PIP_NO_CACHE_DIR=off
-RUN python3 -m venv --system-site-packages --upgrade-deps ${HOME}/.local/venv 
+RUN python3 -m venv --system-site-packages --upgrade-deps /opt/venv 
 # Enable venv
-ENV PATH="${HOME}/.local/venv/bin:$PATH"
+ENV PATH="/opt/venv/bin:$PATH"
 COPY --chown=ros:ros requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
     rm /tmp/requirements.txt

--- a/nvidia.dockerfile
+++ b/nvidia.dockerfile
@@ -253,20 +253,20 @@ ENTRYPOINT ["/opt/entrypoint.sh"]
 EXPOSE 5801
 
 ###########################################
-# Install VSCode
+# Install VSCode (disabled)
 
-RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
-        curl -k -L -o /tmp/vscode.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-arm64' ; \
-    else \
-        curl -k -L -o /tmp/vscode.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64' ; \
-    fi && \
-    apt-get update && apt-get install -y /tmp/vscode.deb && \
-    rm /tmp/vscode.deb && rm -rf /var/lib/apt/lists/*
+# RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+#         curl -k -L -o /tmp/vscode.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-arm64' ; \
+#     else \
+#         curl -k -L -o /tmp/vscode.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64' ; \
+#     fi && \
+#     apt-get update && apt-get install -y /tmp/vscode.deb && \
+#     rm /tmp/vscode.deb && rm -rf /var/lib/apt/lists/*
 
-# Install zrok
-RUN curl -sSLfo /tmp/zrok-install.bash https://get.openziti.io/install.bash && \
-    bash /tmp/zrok-install.bash zrok && \
-    rm /tmp/zrok-install.bash
+# Install zrok (disabled)
+# RUN curl -sSLfo /tmp/zrok-install.bash https://get.openziti.io/install.bash && \
+#     bash /tmp/zrok-install.bash zrok && \
+#     rm /tmp/zrok-install.bash
 
 
 RUN mkdir -p /opt/image && mkdir -p /opt/venv && chown ros:ros /opt/venv
@@ -284,11 +284,11 @@ ENV PIP_NO_CACHE_DIR=off
 RUN python3 -m venv --system-site-packages --upgrade-deps /opt/venv 
 # Enable venv
 ENV PATH="/opt/venv/bin:$PATH"
-COPY --chown=ros:ros requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
-    rm /tmp/requirements.txt
 # needed as quick fix for https://github.com/pypa/setuptools/issues/4483
 RUN pip install -U setuptools[core]
+# COPY --chown=ros:ros requirements.txt /tmp/requirements.txt
+# RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
+#     rm /tmp/requirements.txt
 
 USER root
 COPY .gi? /tmp/gittemp/.git

--- a/nvidia.dockerfile
+++ b/nvidia.dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=nvidia/cuda:11.8.0-runtime-ubuntu22.04
 
 ###########################################
-FROM ${BASE_IMAGE} as base
+FROM ${BASE_IMAGE} AS base
 ARG ROS_DISTRO=humble
 
 ENV ROS_DISTRO=${ROS_DISTRO}
@@ -15,7 +15,7 @@ RUN apt-get update && \
   && locale-gen en_US.UTF-8 \
   && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
   && rm -rf /var/lib/apt/lists/*
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Install timezone
 RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
@@ -63,11 +63,11 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Env vars for the nvidia-container-runtime.
-ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_VISIBLE_DEVICES=all
 # enable all capabilities for the container
 # Explained here: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.10.0/user-guide.html#driver-capabilities
 ENV NVIDIA_DRIVER_CAPABILITIES=all
-ENV QT_X11_NO_MITSHM 1
+ENV QT_X11_NO_MITSHM=1
 
 ENV AMENT_PREFIX_PATH=/opt/ros/${ROS_DISTRO}
 ENV COLCON_PREFIX_PATH=/opt/ros/${ROS_DISTRO}
@@ -139,7 +139,7 @@ ENV LD_LIBRARY_PATH=/opt/ros/${ROS_DISTRO}/lib
 
 
 ###########################################
-FROM dev as lcas
+FROM dev AS lcas
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -186,7 +186,7 @@ RUN apt-get update && apt-get install -y nodejs sudo && \
 
 
 ###########################################
-FROM lcas as openglvnc
+FROM lcas AS openglvnc
 
 ARG ENTRY_POINT=/opt/entrypoint.sh
 ARG TARGETARCH
@@ -272,7 +272,7 @@ RUN curl -sSLfo /tmp/zrok-install.bash https://get.openziti.io/install.bash && \
 RUN mkdir -p /opt/image
 
 ###########################################
-FROM openglvnc as user
+FROM openglvnc AS user
 USER ros
 ENV HOME=/home/ros
 WORKDIR ${HOME}
@@ -280,6 +280,7 @@ RUN mkdir -p ${HOME}/.local/bin
 
 # install a Python venv overlay to allow pip and friends
 ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=off
 RUN python3 -m venv --system-site-packages --upgrade-deps ${HOME}/.local/venv 
 # Enable venv
 ENV PATH="${HOME}/.local/venv/bin:$PATH"


### PR DESCRIPTION
Correct syntax issues in the Dockerfile and modify the setup to create a virtual environment in `/opt/venv`, while disabling the installation of VSCode and zrok.