### PR TITLE
add westonrobot version

### DIFF
--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -22,6 +22,10 @@ jobs:
         fail-fast: false
         matrix:
           include:
+            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:westonrobot-1
+              ros_distro: humble
+              push_tag: westonrobot-humble
+
             - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:jammy-cuda11.8-1
               ros_distro: humble
               push_tag: jammy-cuda11.8-humble


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docker-build-opengl.yaml` file. The change adds a new base image configuration for the Docker build matrix.

* [`.github/workflows/docker-build-opengl.yaml`](diffhunk://#diff-595efa52ba7cdc0240a7d881238485c57b8abec69f6e8bc010050fcde533fb19R25-R28): Added a new base image `lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:westonrobot-1` with `ros_distro` set to `humble` and `push_tag` set to `westonrobot-humble`.