### PR TITLE
upgrade base image

### DIFF
--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -22,23 +22,23 @@ jobs:
         fail-fast: false
         matrix:
           include:
-            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:westonrobot-1.1.2
+            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:westonrobot-1.1.3
               ros_distro: humble
               push_tag: westonrobot-humble
 
-            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:jammy-cuda11.8-1.1.2
+            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:jammy-cuda11.8-1.1.3
               ros_distro: humble
               push_tag: jammy-cuda11.8-humble
 
-            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:jammy-cuda12.1-1.1.2
+            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:jammy-cuda12.1-1.1.3
               ros_distro: humble
               push_tag: jammy-cuda12.1-humble
 
-            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:jammy-cuda12.2-1.1.2
+            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:jammy-cuda12.2-1.1.3
               ros_distro: humble
               push_tag: jammy-cuda12.2-humble
 
-            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:noble-cuda12.6-1.1.2
+            - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:noble-cuda12.6-1.1.3
               ros_distro: rolling
               push_tag: noble-cuda12.6-rolling
   


### PR DESCRIPTION
This pull request updates the base image versions in the Docker build workflow configuration file to ensure compatibility with the latest image versions.

Version updates in the Docker build workflow:

* [`.github/workflows/docker-build-opengl.yaml`](diffhunk://#diff-595efa52ba7cdc0240a7d881238485c57b8abec69f6e8bc010050fcde533fb19L25-R41): Updated the `base_image` versions for multiple configurations from `1.1.2` to `1.1.3`. This affects images for `westonrobot`, `jammy-cuda11.8`, `jammy-cuda12.1`, `jammy-cuda12.2`, and `noble-cuda12.6`. These updates align the workflow with the latest available Docker images.