### PR TITLE
Update ROSDISTRO_INDEX_URL to use correct GitHub URL

### DIFF
--- a/.github/workflows/docker-build-opengl.yaml
+++ b/.github/workflows/docker-build-opengl.yaml
@@ -19,7 +19,9 @@ jobs:
       - lcas
       - qemu
     strategy:
-        fail-fast: false
+        fail-fast: true
+        # let's be sensible with the number we can run at a time
+        max-parallel: 2
         matrix:
           include:
             - base_image: lcas.lincoln.ac.uk/lcas/docker_cuda_desktop:westonrobot-1.1.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN rosdep init || true
 RUN curl -o /etc/ros/rosdep/sources.list.d/20-default.list https://raw.githubusercontent.com/LCAS/rosdistro/master/rosdep/sources.list.d/20-default.list && \
     curl -o /etc/ros/rosdep/sources.list.d/50-lcas.list https://raw.githubusercontent.com/LCAS/rosdistro/master/rosdep/sources.list.d/50-lcas.list
 
-ENV ROSDISTRO_INDEX_URL=https://raw.github.com/LCAS/rosdistro/master/index-v4.yaml
+ENV ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/LCAS/rosdistro/refs/heads/master/index-v4.yaml

--- a/nvidia.dockerfile
+++ b/nvidia.dockerfile
@@ -118,7 +118,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
 
 # provide preconfigured zrok endpoint for lcas
 RUN mkdir -p ${HOME}/.zrok && echo '{"api_endpoint": "https://zrok.zrok.lcas.group", "default_frontend": ""}' > ${HOME}/.zrok/config.json
-RUN mkdir -p ~/.config/rosdistro && echo "index_url: https://raw.github.com/LCAS/rosdistro/master/index-v4.yaml" > ~/.config/rosdistro/config.yaml
+RUN mkdir -p ~/.config/rosdistro && echo "index_url: https://raw.githubusercontent.com/LCAS/rosdistro/refs/heads/master/index-v4.yaml" > ~/.config/rosdistro/config.yaml
 
 # switch to root for further setup ##############################################
 USER root
@@ -172,6 +172,8 @@ USER ros
 RUN mkdir -p ${HOME}/Desktop/ && \
     ln -sf /opt/image/info.md ${HOME}/Desktop/info.md && \
     ln -sf /opt/image/README.md ${HOME}/Desktop/README.md
+
+ENV ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/LCAS/rosdistro/refs/heads/master/index-v4.yaml
 
 RUN rosdep update --rosdistro=${ROS_DISTRO}
 


### PR DESCRIPTION
This pull request updates the `ROSDISTRO_INDEX_URL` environment variable in the `Dockerfile` to use a more precise URL format for the ROS distro index.

* Updated the `ROSDISTRO_INDEX_URL` to use the full GitHub URL with `refs/heads/master`, ensuring the environment variable points to the correct location for the ROS distro index.